### PR TITLE
Add option to pretty print articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^5.0.1",
         "commander": "^9.3.0",
         "get-stdin": "^9.0.0",
         "minisearch": "^5.0.0",
@@ -359,6 +360,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -3107,6 +3119,11 @@
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
+    },
+    "chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
     },
     "check-error": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
+    "chalk": "^5.0.1",
     "commander": "^9.3.0",
     "get-stdin": "^9.0.0",
     "minisearch": "^5.0.0",

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+
+function stats(articles, searchQuery, options) {
+  return chalk.magenta(
+    `Found ${articles.length} articles` +
+    (searchQuery ? ` for "${searchQuery}"` : '') +
+    (options.strict ? ' with strict filtering' : '') + 
+    (options.reverse ? ' in reversed order' : '') +
+    '.'
+  );
+}
+
+function highlight(text, term) {
+  const regex = new RegExp('(' + term + ')', 'gi');
+  
+  return text.replace(regex, chalk.magenta('$1'));
+}
+
+export function prettyArticle(article, searchQuery = '', options) {
+  let title = article.title;
+  let abstract = article.abstract;
+  
+  const searchTerms = (searchQuery ?? '').split(/\s+/);
+
+  for (const term of searchTerms) {
+    title = highlight(title, term);
+    abstract = highlight(abstract, term);
+  }
+
+  return (
+    [
+      chalk.yellow(title),
+      chalk.green(article.authors),
+      chalk.cyan.underline(`https://doi.org/${article.id}`),
+      abstract
+    ].join('\n')
+  );
+}
+
+export function prettyArticles(articles, searchQuery, options) {
+  return [
+    stats(articles, searchQuery, options),
+
+    (articles
+      .map(article => prettyArticle(article, searchQuery, options))
+      .join('\n\n')
+    ),
+
+    stats(articles, searchQuery, options)
+  ].join('\n\n');
+}
+


### PR DESCRIPTION
- Use `-p` for pretty printing.
- Parts of the article are printed in different colours.
- There are statistics at the top and bottom of the results.
- You can also use `-r` to reverse the order of the output.  This is useful for seeing the top result right away in the terminal, since it will be close to your cursor.  Just scroll up to see progressively worse-matching results.

Ref: Pretty print for output of search in CLI #1

For example, if you use `cat example-data/2022-01.json | node hyper-recent.js search -spr "breast cancer"` as your search, then you'll get this:

<img width="1066" alt="Screen Shot 2022-07-18 at 15 45 23" src="https://user-images.githubusercontent.com/989043/179604591-c940b3d5-2bdd-4847-a590-0ebbedc6002a.png">


N.b. link is clickable (just hold the command key when you click).
