### PR TITLE
Refer to id rather than doi in search.

### DIFF
--- a/src/pretty.js
+++ b/src/pretty.js
@@ -31,7 +31,7 @@ export function prettyArticle (article, searchQuery = '', options) {
     [
       chalk.yellow(title),
       chalk.green(article.authors),
-      chalk.cyan.underline(`https://doi.org/${article.doi}`),
+      chalk.cyan.underline(`https://doi.org/${article.id}`),
       abstract
     ].join('\n')
   );


### PR DESCRIPTION
The Search doesn't store a doi field but rather the id. So the pretty printer must not refer to a doi attribute.