### PR TITLE
Categorize papers by recency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,16 @@
       ],
       "program": "${workspaceFolder}/src/data-search.js",
       "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "App",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/src/dashboard/app.js", 
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/src/dashboard/categories.js
+++ b/src/dashboard/categories.js
@@ -9,7 +9,7 @@ export const categories = data.map(({ id, name, description, img }) => ({ id, na
 export const getPapers = ({ id }) => {
   let papers = [];
   const category = data.find(cat => cat.id === id);
-  papers = category && category.papers.map(toDate).sort(byDate).slice(1);
+  papers = category && category.papers.map(toDate).sort(byDate);
   return papers;
 };
 

--- a/src/dashboard/categories.js
+++ b/src/dashboard/categories.js
@@ -6,10 +6,10 @@ const toDate = o => {
 };
 const byDate = (a, b) => { return b.date - a.date; };
 export const categories = data.map(({ id, name, description, img }) => ({ id, name, description, img }));
-export const getPapers = ({ id, limit = 100 }) => {
+export const getPapers = ({ id }) => {
   let papers = [];
   const category = data.find(cat => cat.id === id);
-  papers = category && category.papers.map(toDate).sort(byDate).slice(1, limit);
+  papers = category && category.papers.map(toDate).sort(byDate).slice(1);
   return papers;
 };
 

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -23,30 +23,30 @@ function findRelativeDate (papers, range) {
 
   if (range === 'today') {
     for (const paper of papers) {
-      const paperDate = paper.date.substring(0, 9);
-      if (paperDate === today) {
+      const paperDate = format(paper.date, 'yyyy-MM-dd');
+      if (paperDate >= today) {
         displayPapers.push(paper);
       }
     }
-  } else if (range === 'days') { // if between now & 3 days
-    const startOffset = { days: 3 };
+  } else if (range === 'days') { // within the past 4 days
+    const startOffset = { days: 4 };
     const start = format(sub(now, startOffset), 'yyyy-MM-dd');
 
     for (const paper of papers) {
-      const paperDate = paper.date.substring(0, 9);
+      const paperDate = format(paper.date, 'yyyy-MM-dd');
       if (paperDate >= start && paperDate < today) {
         displayPapers.push(paper);
       }
     }
   } else if (range === 'week') {
     const startOffset = { weeks: 1 };
-    const endOffset = { days: 3 };
+    const endOffset = { days: 4 };
     const start = format(sub(now, startOffset), 'yyyy-MM-dd');
     const end = format(sub(now, endOffset), 'yyyy-MM-dd');
 
     for (const paper of papers) {
-      const paperDate = paper.date.substring(0, 9);
-      if (paperDate >= start && paperDate < end) { // between now & 7 days
+      const paperDate = format(paper.date, 'yyyy-MM-dd');
+      if (paperDate >= start && paperDate < end) { // within the past week
         displayPapers.push(paper);
       }
     }
@@ -57,12 +57,13 @@ function findRelativeDate (papers, range) {
     const end = format(sub(now, endOffset), 'yyyy-MM-dd');
 
     for (const paper of papers) {
-      const paperDate = paper.date.substring(0, 9);
-      if (paperDate >= start && paperDate < end) { // past month
+      const paperDate = format(paper.date, 'yyyy-MM-dd');
+      if (paperDate >= start && paperDate < end) { // everything else within the past month
         displayPapers.push(paper);
       }
     }
   }
+  return displayPapers;
 }
 
 export default function CategoryResultsScreen ({ store }) {
@@ -84,19 +85,19 @@ export default function CategoryResultsScreen ({ store }) {
     ]),
     h('div', { class: 'papers-today' }, [
       h('h2', { class: 'papers-today-title' }, 'New papers today'),
-      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+      h('div', { class: 'papers' }, todayPapers.map(paper => h(Paper, { paper })))
     ]),
     h('div', { class: 'papers-last-few-days' }, [
       h('h2', { class: 'papers-last-few-days-title' }, 'Papers in the last few days'),
-      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+      h('div', { class: 'papers' }, fewDaysPapers.map(paper => h(Paper, { paper })))
     ]),
     h('div', { class: 'papers-last-week' }, [
       h('h2', { class: 'papers-last-week-title' }, 'Papers in the last week'),
-      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+      h('div', { class: 'papers' }, weekPapers.map(paper => h(Paper, { paper })))
     ]),
     h('div', { class: 'papers-this-month' }, [
-      h('h2', { class: 'papers-this-month-title' }, 'Papers this month'),
-      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+      h('h2', { class: 'papers-this-month-title' }, 'Papers in the past month'),
+      h('div', { class: 'papers' }, monthPapers.map(paper => h(Paper, { paper })))
     ])
   ]);
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -47,8 +47,8 @@ export default function CategoryResultsScreen ({ store }) {
   const weekPapers = findRelativeDate(selectedPapers, 'week');
   const monthPapers = findRelativeDate(selectedPapers, 'month');
 
-  return h('div', { class: 'category-results-screen' }, [
-    h(Link, { href: '/', class: 'category-results-reset link' }, '< Select a different topic'), // TODO: < should be a nice SVG icon
+  const resultsScreenElements = [
+    h(Link, { href: '/', class: 'category-results-reset link' }, '< Select a different topic'),
     h('div', { class: 'category-results-info' }, [ // TODO: better css for mobile
       CategoryCard({ category: selectedCategory, store, selectable: false, includeName: false }),
       h('div', { class: 'category-results-details' }, [
@@ -56,22 +56,33 @@ export default function CategoryResultsScreen ({ store }) {
         h('div', { class: 'category-results-date' }, 'Updated yesterday'),
         h('div', { class: 'category-results-description' }, selectedCategory.description)
       ])
-    ]),
-    h('div', { class: 'papers-today' }, [
+    ])
+  ];
+
+  if (todayPapers.length !== 0) {
+    resultsScreenElements.push(h('div', { class: 'papers-today' }, [
       h('h2', { class: 'papers-today-title' }, 'New papers today'),
       h('div', { class: 'papers' }, todayPapers.map(paper => h(Paper, { paper })))
-    ]),
-    h('div', { class: 'papers-last-few-days' }, [
+    ]));
+  }
+  if (fewDaysPapers.length !== 0) {
+    resultsScreenElements.push(h('div', { class: 'papers-last-few-days' }, [
       h('h2', { class: 'papers-last-few-days-title' }, 'Papers in the last few days'),
       h('div', { class: 'papers' }, fewDaysPapers.map(paper => h(Paper, { paper })))
-    ]),
-    h('div', { class: 'papers-last-week' }, [
+    ]));
+  }
+  if (weekPapers.length !== 0) {
+    resultsScreenElements.push(h('div', { class: 'papers-last-week' }, [
       h('h2', { class: 'papers-last-week-title' }, 'Papers in the last week'),
       h('div', { class: 'papers' }, weekPapers.map(paper => h(Paper, { paper })))
-    ]),
-    h('div', { class: 'papers-this-month' }, [
+    ]));
+  }
+  if (monthPapers.length !== 0) {
+    resultsScreenElements.push(h('div', { class: 'category-results-papers-this-month' }, [
       h('h2', { class: 'papers-this-month-title' }, 'Papers in the past month'),
       h('div', { class: 'papers' }, monthPapers.map(paper => h(Paper, { paper })))
-    ])
-  ]);
+    ]));
+  }
+
+  return h('div', { class: 'category-results-screen' }, resultsScreenElements);
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { Link } from 'preact-router/match';
 import CategoryCard from './category-card.js';
-import { format, sub, isWithinInterval } from 'date-fns';
+import { sub } from 'date-fns';
 
 function Paper ({ paper }) {
   return h('div', { class: 'paper' }, [
@@ -18,78 +18,31 @@ function Paper ({ paper }) {
 
 function findRelativeDate (papers, range) {
   const now = new Date();
-  // const today = format(now, 'yyyy-MM-dd');
+  const today = now.toISOString().split('T')[0];
+  const daysAgo = sub(now, { days: 4 }).toISOString();
+  const weekAgo = sub(now, { weeks: 1 }).toISOString();
+  const monthAgo = sub(now, { months: 1 }).toISOString();
   const displayPapers = [];
 
   for (const paper of papers) {
-    const paperDate = new Date(paper.date);
+    const paperDate = paper.date.toISOString().split('T')[0];
 
-    if (range === 'today' && isWithinInterval(paperDate, { start: now, end: now })) { // Today's papers
+    if (range === 'today' && paperDate === today) { // Today's papers
       displayPapers.push(paper);
-    } else if (range === 'days' && isWithinInterval(paperDate, { start: sub(now, { days: 4 }), end: sub(now, { days: 1 }) })) { // Papers from 4 days ago
+    } else if (range === 'days' && paperDate >= daysAgo && paperDate < today) { // Papers from 4 days ago
       displayPapers.push(paper);
-    } else if (range === 'week' && isWithinInterval(paperDate, { start: sub(now, { weeks: 1 }), end: sub(now, { days: 4 }) })) { // Papers from past week
+    } else if (range === 'week' && paperDate >= weekAgo && paperDate < daysAgo) { // Papers from past week
       displayPapers.push(paper);
-    } else if (range === 'month' && isWithinInterval(paperDate, { start: sub(now, { months: 1 }), end: sub(now, { weeks: 1 }) })) { // Rest of the papers from the past month
+    } else if (range === 'month' && paperDate >= monthAgo && paperDate < weekAgo) { // Rest of the papers from the past month
       displayPapers.push(paper);
-    } else {
-      console.log('didnt work');
     }
   }
-
-  // if (range === 'today') {
-  //   console.log('today date: ' + today);
-  //   for (const paper of papers) {
-  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
-  //     console.log('PAPER DATE: ' + paperDate);
-  //     if (paperDate === today) {
-  //       displayPapers.push(paper);
-  //     }
-  //   }
-  // } else if (range === 'days') { // within the past 4 days
-  //   const startOffset = { days: 4 };
-  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
-
-  //   for (const paper of papers) {
-  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
-  //     if (paperDate >= start && paperDate < today) {
-  //       displayPapers.push(paper);
-  //     }
-  //   }
-  // } else if (range === 'week') {
-  //   const startOffset = { weeks: 1 };
-  //   const endOffset = { days: 4 };
-  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
-  //   const end = format(sub(now, endOffset), 'yyyy-MM-dd');
-
-  //   for (const paper of papers) {
-  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
-  //     if (paperDate >= start && paperDate < end) { // within the past week
-  //       displayPapers.push(paper);
-  //     }
-  //   }
-  // } else {
-  //   const startOffset = { months: 1 };
-  //   const endOffset = { weeks: 1 };
-  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
-  //   const end = format(sub(now, endOffset), 'yyyy-MM-dd');
-
-  //   for (const paper of papers) {
-  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
-  //     if (paperDate >= start && paperDate < end) { // everything else within the past month
-  //       displayPapers.push(paper);
-  //     }
-  //   }
-  // }
   return displayPapers;
 }
 
 export default function CategoryResultsScreen ({ store }) {
   const { selectedPapers, selectedCategory } = store;
   const todayPapers = findRelativeDate(selectedPapers, 'today');
-  console.log('TODAYS PAPERS: ');
-  console.log(todayPapers);
-
   const fewDaysPapers = findRelativeDate(selectedPapers, 'days');
   const weekPapers = findRelativeDate(selectedPapers, 'week');
   const monthPapers = findRelativeDate(selectedPapers, 'month');

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { Link } from 'preact-router/match';
 import CategoryCard from './category-card.js';
+import { format, sub } from 'date-fns';
 
 function Paper ({ paper }) {
   return h('div', { class: 'paper' }, [
@@ -13,6 +14,51 @@ function Paper ({ paper }) {
     h('div', { class: 'paper-journal' }, paper.journal),
     h('div', { class: 'paper-brief' }, paper.brief)
   ]);
+}
+
+function findRelativeDate (papers, range) {
+  const now = new Date();
+  const today = format(now, 'yyyy-MM-dd');
+  const displayPapers = [];
+
+  if (range === 'today') {
+    for (const paper of papers) {
+      const paperDate = paper.date.substring(0, 9);
+      if (paperDate === today) {
+        displayPapers.push(paper);
+      }
+    }
+  } else if (range === 'days') { // if between now & 3 days
+    const startOffset = { days: 3 };
+    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+
+    for (const paper of papers) {
+      const paperDate = paper.date.substring(0, 9);
+      if (paperDate >= start && paperDate <= today) {
+        displayPapers.push(paper);
+      }
+    }
+  } else if (range === 'week') {
+    const startOffset = { weeks: 1 };
+    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+
+    for (const paper of papers) {
+      const paperDate = paper.date.substring(0, 9);
+      if (paperDate >= start && paperDate <= today) { // between now & 7 days
+        displayPapers.push(paper);
+      }
+    }
+  } else {
+    const startOffset = { motnhs: 1 };
+    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+
+    for (const paper of papers) {
+      const paperDate = paper.date.substring(0, 9);
+      if (paperDate >= start && paperDate <= today) { // past month
+        displayPapers.push(paper);
+      }
+    }
+  }
 }
 
 export default function CategoryResultsScreen ({ store }) {

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { Link } from 'preact-router/match';
 import CategoryCard from './category-card.js';
-import { format, sub } from 'date-fns';
+import { format, sub, isWithinInterval } from 'date-fns';
 
 function Paper ({ paper }) {
   return h('div', { class: 'paper' }, [
@@ -18,57 +18,78 @@ function Paper ({ paper }) {
 
 function findRelativeDate (papers, range) {
   const now = new Date();
-  const today = format(now, 'yyyy-MM-dd');
+  // const today = format(now, 'yyyy-MM-dd');
   const displayPapers = [];
 
-  if (range === 'today') {
-    for (const paper of papers) {
-      const paperDate = format(paper.date, 'yyyy-MM-dd');
-      if (paperDate === today) {
-        displayPapers.push(paper);
-      }
-    }
-  } else if (range === 'days') { // within the past 4 days
-    const startOffset = { days: 4 };
-    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+  for (const paper of papers) {
+    const paperDate = new Date(paper.date);
 
-    for (const paper of papers) {
-      const paperDate = format(paper.date, 'yyyy-MM-dd');
-      if (paperDate >= start && paperDate < today) {
-        displayPapers.push(paper);
-      }
-    }
-  } else if (range === 'week') {
-    const startOffset = { weeks: 1 };
-    const endOffset = { days: 4 };
-    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
-    const end = format(sub(now, endOffset), 'yyyy-MM-dd');
-
-    for (const paper of papers) {
-      const paperDate = format(paper.date, 'yyyy-MM-dd');
-      if (paperDate >= start && paperDate < end) { // within the past week
-        displayPapers.push(paper);
-      }
-    }
-  } else {
-    const startOffset = { months: 1 };
-    const endOffset = { weeks: 1 };
-    const start = format(sub(now, startOffset), 'yyyy-MM-dd');
-    const end = format(sub(now, endOffset), 'yyyy-MM-dd');
-
-    for (const paper of papers) {
-      const paperDate = format(paper.date, 'yyyy-MM-dd');
-      if (paperDate >= start && paperDate < end) { // everything else within the past month
-        displayPapers.push(paper);
-      }
+    if (range === 'today' && isWithinInterval(paperDate, { start: now, end: now })) { // Today's papers
+      displayPapers.push(paper);
+    } else if (range === 'days' && isWithinInterval(paperDate, { start: sub(now, { days: 4 }), end: sub(now, { days: 1 }) })) { // Papers from 4 days ago
+      displayPapers.push(paper);
+    } else if (range === 'week' && isWithinInterval(paperDate, { start: sub(now, { weeks: 1 }), end: sub(now, { days: 4 }) })) { // Papers from past week
+      displayPapers.push(paper);
+    } else if (range === 'month' && isWithinInterval(paperDate, { start: sub(now, { months: 1 }), end: sub(now, { weeks: 1 }) })) { // Rest of the papers from the past month
+      displayPapers.push(paper);
+    } else {
+      console.log('didnt work');
     }
   }
+
+  // if (range === 'today') {
+  //   console.log('today date: ' + today);
+  //   for (const paper of papers) {
+  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
+  //     console.log('PAPER DATE: ' + paperDate);
+  //     if (paperDate === today) {
+  //       displayPapers.push(paper);
+  //     }
+  //   }
+  // } else if (range === 'days') { // within the past 4 days
+  //   const startOffset = { days: 4 };
+  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+
+  //   for (const paper of papers) {
+  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
+  //     if (paperDate >= start && paperDate < today) {
+  //       displayPapers.push(paper);
+  //     }
+  //   }
+  // } else if (range === 'week') {
+  //   const startOffset = { weeks: 1 };
+  //   const endOffset = { days: 4 };
+  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+  //   const end = format(sub(now, endOffset), 'yyyy-MM-dd');
+
+  //   for (const paper of papers) {
+  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
+  //     if (paperDate >= start && paperDate < end) { // within the past week
+  //       displayPapers.push(paper);
+  //     }
+  //   }
+  // } else {
+  //   const startOffset = { months: 1 };
+  //   const endOffset = { weeks: 1 };
+  //   const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+  //   const end = format(sub(now, endOffset), 'yyyy-MM-dd');
+
+  //   for (const paper of papers) {
+  //     const paperDate = format(paper.date, 'yyyy-MM-dd');
+  //     if (paperDate >= start && paperDate < end) { // everything else within the past month
+  //       displayPapers.push(paper);
+  //     }
+  //   }
+  // }
   return displayPapers;
 }
 
 export default function CategoryResultsScreen ({ store }) {
   const { selectedPapers, selectedCategory } = store;
   const todayPapers = findRelativeDate(selectedPapers, 'today');
+  console.log('TODAYS PAPERS: ');
+  console.log(todayPapers);
+
   const fewDaysPapers = findRelativeDate(selectedPapers, 'days');
   const weekPapers = findRelativeDate(selectedPapers, 'week');
   const monthPapers = findRelativeDate(selectedPapers, 'month');

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -34,27 +34,31 @@ function findRelativeDate (papers, range) {
 
     for (const paper of papers) {
       const paperDate = paper.date.substring(0, 9);
-      if (paperDate >= start && paperDate <= today) {
+      if (paperDate >= start && paperDate < today) {
         displayPapers.push(paper);
       }
     }
   } else if (range === 'week') {
     const startOffset = { weeks: 1 };
+    const endOffset = { days: 3 };
     const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+    const end = format(sub(now, endOffset), 'yyyy-MM-dd');
 
     for (const paper of papers) {
       const paperDate = paper.date.substring(0, 9);
-      if (paperDate >= start && paperDate <= today) { // between now & 7 days
+      if (paperDate >= start && paperDate < end) { // between now & 7 days
         displayPapers.push(paper);
       }
     }
   } else {
-    const startOffset = { motnhs: 1 };
+    const startOffset = { months: 1 };
+    const endOffset = { weeks: 1 };
     const start = format(sub(now, startOffset), 'yyyy-MM-dd');
+    const end = format(sub(now, endOffset), 'yyyy-MM-dd');
 
     for (const paper of papers) {
       const paperDate = paper.date.substring(0, 9);
-      if (paperDate >= start && paperDate <= today) { // past month
+      if (paperDate >= start && paperDate < end) { // past month
         displayPapers.push(paper);
       }
     }
@@ -63,6 +67,10 @@ function findRelativeDate (papers, range) {
 
 export default function CategoryResultsScreen ({ store }) {
   const { selectedPapers, selectedCategory } = store;
+  const todayPapers = findRelativeDate(selectedPapers, 'today');
+  const fewDaysPapers = findRelativeDate(selectedPapers, 'days');
+  const weekPapers = findRelativeDate(selectedPapers, 'week');
+  const monthPapers = findRelativeDate(selectedPapers, 'month');
 
   return h('div', { class: 'category-results-screen' }, [
     h(Link, { href: '/', class: 'category-results-reset link' }, '< Select a different topic'), // TODO: < should be a nice SVG icon

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -28,6 +28,21 @@ export default function CategoryResultsScreen ({ store }) {
         h('div', { class: 'category-results-description' }, selectedCategory.description)
       ])
     ]),
-    h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+    h('div', { class: 'papers-today' }, [
+      h('h2', { class: 'papers-today-title' }, 'New papers today'),
+      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+    ]),
+    h('div', { class: 'papers-last-few-days' }, [
+      h('h2', { class: 'papers-last-few-days-title' }, 'Papers in the last few days'),
+      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+    ]),
+    h('div', { class: 'papers-last-week' }, [
+      h('h2', { class: 'papers-last-week-title' }, 'Papers in the last week'),
+      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+    ]),
+    h('div', { class: 'papers-this-month' }, [
+      h('h2', { class: 'papers-this-month-title' }, 'Papers this month'),
+      h('div', { class: 'papers' }, selectedPapers.map(paper => h(Paper, { paper })))
+    ])
   ]);
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -24,7 +24,7 @@ function findRelativeDate (papers, range) {
   if (range === 'today') {
     for (const paper of papers) {
       const paperDate = format(paper.date, 'yyyy-MM-dd');
-      if (paperDate >= today) {
+      if (paperDate === today) {
         displayPapers.push(paper);
       }
     }

--- a/src/dashboard/category-selection-screen.js
+++ b/src/dashboard/category-selection-screen.js
@@ -8,7 +8,7 @@ export default function CategorySelectionScreen ({ store }) {
 
   return h('div', { class: 'category-selection-screen' }, [
     h('div', { class: 'app-name' }, 'The Digest'),
-    h('div', { class: 'app-tagline' }, 'Quick acess to the latest papers in the biomedicine.'),
+    h('div', { class: 'app-tagline' }, 'Quick access to the latest papers in the biomedicine.'),
     h('div', { class: 'categories' }, (haveCategories
       ? categories.map(category => h(CategoryCard, { category, store }))
       : h('div', {}, 'No categories!')


### PR DESCRIPTION
Filters through all recent papers from the past month and creates the following categories/headings in the UI:
- Today's papers
- Papers from the past 3 days
- Papers from the past week
- Rest of the papers from this month