### PR TITLE
23 author affiliation

### DIFF
--- a/src/dashboard/category-results-screen.css
+++ b/src/dashboard/category-results-screen.css
@@ -82,3 +82,25 @@
   margin-top: -0.25em;
   margin-left: -1.125em;
 }
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  border-bottom: 1px dotted black;
+}

--- a/src/dashboard/category-results-screen.css
+++ b/src/dashboard/category-results-screen.css
@@ -1,5 +1,6 @@
 .category-results-screen {
   margin: 2em;
+  overflow: hidden;
 }
 
 .category-results-screen .category {
@@ -90,17 +91,31 @@
 
 .tooltip .tooltiptext {
   visibility: hidden;
-  width: 120px;
+  width: max-content;
+  max-width: 120px;
   background-color: black;
   color: #fff;
   text-align: center;
-  padding: 5px 0;
+  padding: 5px;
   border-radius: 6px;
   position: absolute;
   z-index: 1;
+  opacity: 0;
+  transition: opacity 0.5s;
 }
 
 .tooltip:hover .tooltiptext {
   visibility: visible;
-  border-bottom: 1px dotted black;
+  opacity: 1;
+}
+
+.tooltip .tooltiptext::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent black transparent;
 }

--- a/src/dashboard/category-results-screen.css
+++ b/src/dashboard/category-results-screen.css
@@ -1,6 +1,5 @@
 .category-results-screen {
   margin: 2em;
-  overflow: hidden;
 }
 
 .category-results-screen .category {
@@ -87,12 +86,13 @@
 .tooltip {
   position: relative;
   display: inline-block;
+  border-bottom: 1px dotted black;
 }
 
 .tooltip .tooltiptext {
   visibility: hidden;
   width: max-content;
-  max-width: 120px;
+  max-width: 200px;
   background-color: black;
   color: #fff;
   text-align: center;
@@ -112,10 +112,10 @@
 .tooltip .tooltiptext::after {
   content: " ";
   position: absolute;
-  bottom: 100%;
-  left: 50%;
-  margin-left: -5px;
+  top: 50%;
+  right: 100%;
+  margin-top: -5px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent transparent black transparent;
+  border-color: transparent black transparent transparent;
 }

--- a/src/dashboard/category-results-screen.css
+++ b/src/dashboard/category-results-screen.css
@@ -58,6 +58,11 @@
   position: relative;
 }
 
+.paper-institution {
+  color: #888;
+  font-size: 0.9em;
+}
+
 .paper-date {
   color: #888;
   font-size: 0.8em;
@@ -81,41 +86,4 @@
   top: 50%;
   margin-top: -0.25em;
   margin-left: -1.125em;
-}
-
-.tooltip {
-  position: relative;
-  display: inline-block;
-  border-bottom: 1px dotted black;
-}
-
-.tooltip .tooltiptext {
-  visibility: hidden;
-  width: max-content;
-  max-width: 200px;
-  background-color: black;
-  color: #fff;
-  text-align: center;
-  padding: 5px;
-  border-radius: 6px;
-  position: absolute;
-  z-index: 1;
-  opacity: 0;
-  transition: opacity 0.5s;
-}
-
-.tooltip:hover .tooltiptext {
-  visibility: visible;
-  opacity: 1;
-}
-
-.tooltip .tooltiptext::after {
-  content: " ";
-  position: absolute;
-  top: 50%;
-  right: 100%;
-  margin-top: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent black transparent transparent;
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -9,7 +9,9 @@ function Paper ({ paper }) {
       h('div', { class: 'paper-read' }),
       h('div', { class: 'paper-title' }, paper.title)
     ]),
-    h('div', { class: 'paper-authors' }, paper.authors),
+    h('div', { class: 'paper-authors tooltip' }, paper.authors, [
+      h('span', { class: 'tooltiptext' }, paper.author_corresponding_institution)
+    ]),
     h('div', { class: 'paper-date' }, paper.date.toISOString().split('T')[0]),
     h('div', { class: 'paper-journal' }, paper.journal),
     h('div', { class: 'paper-brief' }, paper.brief)

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -30,15 +30,18 @@ function findCorrespondingAuthor (paper) {
     return;
   }
 
-  const authorsArray = paper.authors.split(';'); // "Prasad, P.; Chongtham, J.; Tripathi, S. C.; Ganguly, N. K.; Mittal, S. A.; Srivastava, T."
+  const authorsArray = paper.authors.split(';');
+
+  const removeAccents = str => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const corrAuthor = removeAccents(paper.author_corresponding);
 
   const regexPattern = /\s+/g;
-  const corrNameArray = paper.author_corresponding.replace(regexPattern, ' ').split(' '); // "Shivani Arora Mittal" in an array
-  const corrLastName = corrNameArray[corrNameArray.length - 1]; // "Mittal" last name
+  const corrNameArray = corrAuthor.replace(regexPattern, ' ').split(' '); // replacing extra spaces in name input & creating array
+  const corrLastName = corrNameArray[corrNameArray.length - 1];
 
   for (const name of authorsArray) {
     const nameArray = name.split(','); // Tripathi, S. C. into ['Tripathi', 'S. C.']
-    const lastName = nameArray[0].trim(); // Tripathi
+    const lastName = nameArray[0].trim();
     let initialsArray = [];
 
     const corrInitialsArray = corrNameArray.map(word => word[0].trim());

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -26,16 +26,18 @@ function Paper ({ paper }) {
 }
 
 function findCorrespondingAuthor (paper) {
-  const authors = paper.authors.split(';');
-  const nameArray = paper.author_corresponding.split(' ');
-  const lastName = nameArray[nameArray.length - 1];
+  const authorsArray = paper.authors.split(';'); // "Prasad, P.; Chongtham, J.; Tripathi, S. C.; Ganguly, N. K.; Mittal, S. A.; Srivastava, T."
 
-  for (const author of authors) {
-    const fullName = author.split(',');
-    const last = fullName[0].trim();
+  const regexPattern = /\s+/g;
+  const corrNameArray = paper.author_corresponding.replace(regexPattern, ' ').split(' '); // "Shivani Arora Mittal" in an array
+  const corrLastName = corrNameArray[corrNameArray.length - 1]; // "Mittal" last name
 
-    if (last === lastName) {
-      return author;
+  for (const name of authorsArray) {
+    const nameArray = name.split(','); // Tripathi, S. C. into ['Tripathi', 'S. C.']
+    const lastName = nameArray[0].trim(); // Tripathi
+
+    if (lastName === corrLastName) { // matches last name of corresponding author
+      return name;
     }
   }
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -4,7 +4,7 @@ import CategoryCard from './category-card.js';
 import { sub } from 'date-fns';
 
 function Paper ({ paper }) {
-  const corrAuthor = findCorrespondingAuthor(paper).toString();
+  const corrAuthor = findCorrespondingAuthor(paper);
 
   const paperElements = [
     h('a', { href: paper.finalURL, target: '_blank', class: 'paper-link' }, [

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -4,76 +4,17 @@ import CategoryCard from './category-card.js';
 import { sub } from 'date-fns';
 
 function Paper ({ paper }) {
-  const corrAuthor = findCorrespondingAuthor(paper);
-
-  const paperElements = [
+  return h('div', { class: 'paper' }, [
     h('a', { href: paper.finalURL, target: '_blank', class: 'paper-link' }, [
       h('div', { class: 'paper-read' }),
       h('div', { class: 'paper-title' }, paper.title)
     ]),
-    h('div', { class: 'paper-authors' }, finalizeAuthorsList(paper.authors, corrAuthor), [
-      h('span', { class: 'paper.authors tooltip' }, corrAuthor, [
-        h('span', { class: 'tooltiptext' }, paper.author_corresponding_institution)
-      ])
-    ])
-  ];
-
-  paperElements.push(
+    h('div', { class: 'paper-authors' }, paper.authors),
+    h('div', { class: 'paper-institution' }, paper.author_corresponding_institution),
     h('div', { class: 'paper-date' }, paper.date.toISOString().split('T')[0]),
     h('div', { class: 'paper-journal' }, paper.journal),
     h('div', { class: 'paper-brief' }, paper.brief)
-  );
-
-  return h('div', { class: 'paper' }, paperElements);
-}
-
-function findCorrespondingAuthor (paper) {
-  if (!paper.author_corresponding) {
-    return;
-  }
-
-  const authorsArray = paper.authors.split(';');
-
-  const removeAccents = str => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-  const corrAuthor = removeAccents(paper.author_corresponding);
-
-  const regexPattern = /\s+/g;
-  const corrNameArray = corrAuthor.replace(regexPattern, ' ').split(' '); // replacing extra spaces in name input & creating array
-  const corrLastName = corrNameArray[corrNameArray.length - 1];
-
-  for (const name of authorsArray) {
-    const nameArray = name.split(','); // split up last name from initials
-    const lastName = nameArray[0].trim();
-    let initialsArray = [];
-
-    const corrInitialsArray = corrNameArray.map(word => word[0].trim());
-    corrInitialsArray.pop();
-    console.log(corrInitialsArray);
-
-    if (nameArray[1]) {
-      const rawInitials = nameArray[1].split('.');
-      console.log(rawInitials);
-      initialsArray = rawInitials.map((element) => element.trim());
-      initialsArray.pop();
-      console.log(initialsArray);
-    }
-
-    if (lastName === corrLastName && initialsArray.length === corrInitialsArray.length) {
-      const sameInitials = initialsArray.every((element, index) => element === corrInitialsArray[index]);
-
-      if (sameInitials) {
-        return name;
-      }
-    }
-  }
-}
-
-function finalizeAuthorsList (authorString, corrAuthor) {
-  const authorsArray = authorString.split(';');
-  const finalAuthorsArray = authorsArray.filter(name => name !== corrAuthor);
-  let finalAuthorsList = finalAuthorsArray.join(';');
-  finalAuthorsList = finalAuthorsList + '; ';
-  return finalAuthorsList;
+  ]);
 }
 
 function findRelativeDate (papers, range) {

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -4,13 +4,15 @@ import CategoryCard from './category-card.js';
 import { sub } from 'date-fns';
 
 function Paper ({ paper }) {
+  const corrAuthor = findCorrespondingAuthor(paper).toString();
+
   const paperElements = [
     h('a', { href: paper.finalURL, target: '_blank', class: 'paper-link' }, [
       h('div', { class: 'paper-read' }),
       h('div', { class: 'paper-title' }, paper.title)
     ]),
-    h('div', { class: 'paper-authors' }, paper.authors, [
-      h('span', { class: 'paper.authors tooltip' }, findCorrespondingAuthor(paper), [
+    h('div', { class: 'paper-authors' }, finalizeAuthorsList(paper.authors, corrAuthor), [
+      h('span', { class: 'paper.authors tooltip' }, corrAuthor, [
         h('span', { class: 'tooltiptext' }, paper.author_corresponding_institution)
       ])
     ])
@@ -40,7 +42,7 @@ function findCorrespondingAuthor (paper) {
   const corrLastName = corrNameArray[corrNameArray.length - 1];
 
   for (const name of authorsArray) {
-    const nameArray = name.split(','); // Tripathi, S. C. into ['Tripathi', 'S. C.']
+    const nameArray = name.split(','); // split up last name from initials
     const lastName = nameArray[0].trim();
     let initialsArray = [];
 
@@ -56,7 +58,7 @@ function findCorrespondingAuthor (paper) {
       console.log(initialsArray);
     }
 
-    if (lastName === corrLastName && initialsArray.length === corrInitialsArray.length) { // matches last name of corresponding author
+    if (lastName === corrLastName && initialsArray.length === corrInitialsArray.length) {
       const sameInitials = initialsArray.every((element, index) => element === corrInitialsArray[index]);
 
       if (sameInitials) {
@@ -64,6 +66,14 @@ function findCorrespondingAuthor (paper) {
       }
     }
   }
+}
+
+function finalizeAuthorsList (authorString, corrAuthor) {
+  const authorsArray = authorString.split(';');
+  const finalAuthorsArray = authorsArray.filter(name => name !== corrAuthor);
+  let finalAuthorsList = finalAuthorsArray.join(';');
+  finalAuthorsList = finalAuthorsList + '; ';
+  return finalAuthorsList;
 }
 
 function findRelativeDate (papers, range) {

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -26,6 +26,10 @@ function Paper ({ paper }) {
 }
 
 function findCorrespondingAuthor (paper) {
+  if (!paper.author_corresponding) {
+    return;
+  }
+
   const authorsArray = paper.authors.split(';'); // "Prasad, P.; Chongtham, J.; Tripathi, S. C.; Ganguly, N. K.; Mittal, S. A.; Srivastava, T."
 
   const regexPattern = /\s+/g;
@@ -35,9 +39,26 @@ function findCorrespondingAuthor (paper) {
   for (const name of authorsArray) {
     const nameArray = name.split(','); // Tripathi, S. C. into ['Tripathi', 'S. C.']
     const lastName = nameArray[0].trim(); // Tripathi
+    let initialsArray = [];
 
-    if (lastName === corrLastName) { // matches last name of corresponding author
-      return name;
+    const corrInitialsArray = corrNameArray.map(word => word[0].trim());
+    corrInitialsArray.pop();
+    console.log(corrInitialsArray);
+
+    if (nameArray[1]) {
+      const rawInitials = nameArray[1].split('.');
+      console.log(rawInitials);
+      initialsArray = rawInitials.map((element) => element.trim());
+      initialsArray.pop();
+      console.log(initialsArray);
+    }
+
+    if (lastName === corrLastName && initialsArray.length === corrInitialsArray.length) { // matches last name of corresponding author
+      const sameInitials = initialsArray.every((element, index) => element === corrInitialsArray[index]);
+
+      if (sameInitials) {
+        return name;
+      }
     }
   }
 }

--- a/src/dashboard/category-results-screen.js
+++ b/src/dashboard/category-results-screen.js
@@ -4,18 +4,40 @@ import CategoryCard from './category-card.js';
 import { sub } from 'date-fns';
 
 function Paper ({ paper }) {
-  return h('div', { class: 'paper' }, [
+  const paperElements = [
     h('a', { href: paper.finalURL, target: '_blank', class: 'paper-link' }, [
       h('div', { class: 'paper-read' }),
       h('div', { class: 'paper-title' }, paper.title)
     ]),
-    h('div', { class: 'paper-authors tooltip' }, paper.authors, [
-      h('span', { class: 'tooltiptext' }, paper.author_corresponding_institution)
-    ]),
+    h('div', { class: 'paper-authors' }, paper.authors, [
+      h('span', { class: 'paper.authors tooltip' }, findCorrespondingAuthor(paper), [
+        h('span', { class: 'tooltiptext' }, paper.author_corresponding_institution)
+      ])
+    ])
+  ];
+
+  paperElements.push(
     h('div', { class: 'paper-date' }, paper.date.toISOString().split('T')[0]),
     h('div', { class: 'paper-journal' }, paper.journal),
     h('div', { class: 'paper-brief' }, paper.brief)
-  ]);
+  );
+
+  return h('div', { class: 'paper' }, paperElements);
+}
+
+function findCorrespondingAuthor (paper) {
+  const authors = paper.authors.split(';');
+  const nameArray = paper.author_corresponding.split(' ');
+  const lastName = nameArray[nameArray.length - 1];
+
+  for (const author of authors) {
+    const fullName = author.split(',');
+    const last = fullName[0].trim();
+
+    if (last === lastName) {
+      return author;
+    }
+  }
 }
 
 function findRelativeDate (papers, range) {

--- a/src/search.js
+++ b/src/search.js
@@ -12,7 +12,7 @@ export class Search {
   constructor () {
     this.miniSearch = new MiniSearch({
       fields: ['title', 'authors', 'category', 'abstract'], // fields to index for full-text search
-      storeFields: ['title', 'authors', 'category', 'abstract', 'date', 'server', 'doi', 'version'] // fields to return with search results
+      storeFields: ['title', 'authors', 'category', 'abstract', 'date', 'server', 'doi', 'version', 'author_corresponding', 'author_corresponding_institution'] // fields to return with search results
     });
   }
 


### PR DESCRIPTION
Adding author affiliation for the corresponding author only, and making sure no author names are duplicated in the list by doing so. In the API response we get, the author list is in the form of `lastName, initials` but the corresponding author is listed by their full name. So, a bit of filtering and comparison is involved to make sure we have the right author's affiliation linked. Some cases I'm considering here that would affect the process of searching for the corresponding author name in the full author list:

- Authors who have the same last name
- Authors with accents in their name
- Authors who have last names of multiple words separated by spaces (not hyphenated, like "Pryce Roberts, A.")